### PR TITLE
Allowing our JSON+LD parser to process bad date strings

### DIFF
--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -32,7 +32,13 @@ class RecipeParser_Parser_MicrodataJsonLd {
         }
         if (property_exists($data, "cookTime")) {
             $cookTime = self::cleanDuration($data->cookTime);
-            $recipe->time['cook'] = $cookTime ? RecipeParser_Text::formatISO_8601($cookTime) : null;
+            $parsed_time = null;
+            try {
+                $parsed_time = RecipeParser_Text::formatISO_8601($cookTime);
+            } catch (\Exception $e) {
+                $parsed_time = null;
+            }
+            $recipe->time['cook'] = $parsed_time;
         }
         if (property_exists($data, "totalTime")) {
             $totalTime = self::cleanDuration($data->totalTime);


### PR DESCRIPTION
## Change Summary
We are now allowing bad date format when scraping using our json+ld scraper.
## Release Notes
There are no special notes. This needs to be deployed as a part of our chicory-scraper deployment process.
## Testing
We need to make sure that we can scrape the mentioned recipe successfully.
